### PR TITLE
feat(nvim): add indent-blankline plugin

### DIFF
--- a/nvim/.config/nvim/lua/plugins/indent.lua
+++ b/nvim/.config/nvim/lua/plugins/indent.lua
@@ -1,0 +1,12 @@
+return {
+        "lukas-reineke/indent-blankline.nvim",
+        main = "ibl",
+        event = { "BufReadPre", "BufNewFile" },
+        config = function()
+                require("ibl").setup({
+                        exclude = {
+                                filetypes = { "help", "alpha", "neo-tree", "Trouble", "lazy" },
+                        },
+                })
+        end,
+}


### PR DESCRIPTION
## Summary
- add indent-blankline plugin configured via ibl
- exclude common UI filetypes from indentation guides